### PR TITLE
⚡️ vue 的 vite-render-code 使用 ast 实现

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,12 +240,18 @@ importers:
         specifier: ^4.3.2
         version: 4.3.2(vue@3.4.21(typescript@5.2.2))
     devDependencies:
+      '@babel/types':
+        specifier: ^7.24.5
+        version: 7.24.5
       '@types/node':
         specifier: ^20.12.11
         version: 20.12.11
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
         version: 5.0.4(vite@5.0.12(@types/node@20.12.11)(less@4.2.0))(vue@3.4.21(typescript@5.2.2))
+      '@vue/compiler-dom':
+        specifier: 3.4.21
+        version: 3.4.21
       '@vue/compiler-sfc':
         specifier: ^3.4.27
         version: 3.4.27
@@ -713,6 +719,7 @@ packages:
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -720,6 +727,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@jridgewell/gen-mapping@0.3.5':
     resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
@@ -1611,6 +1619,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
@@ -1717,6 +1726,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2402,6 +2412,7 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rollup-plugin-external-globals@0.10.0:
@@ -3532,7 +3543,7 @@ snapshots:
   '@vue/language-core@2.0.6(typescript@5.2.2)':
     dependencies:
       '@volar/language-core': 2.1.6
-      '@vue/compiler-dom': 3.4.27
+      '@vue/compiler-dom': 3.4.21
       '@vue/shared': 3.4.27
       computeds: 0.0.1
       minimatch: 9.0.4

--- a/site/vue3/package.json
+++ b/site/vue3/package.json
@@ -20,8 +20,10 @@
     "vue-router": "^4.3.2"
   },
   "devDependencies": {
+    "@babel/types": "^7.24.5",
     "@types/node": "^20.12.11",
     "@vitejs/plugin-vue": "^5.0.4",
+    "@vue/compiler-dom": "3.4.21",
     "@vue/compiler-sfc": "^3.4.27",
     "less": "^4.2.0",
     "less-loader": "^12.2.0",

--- a/site/vue3/vite.config.ts
+++ b/site/vue3/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   },
   base: "/vue3/",
   plugins: [
-    vue(),
+    viteRenderCode(vue),
     AutoImport({
       resolvers: [ArcoResolver()],
     }),
@@ -25,7 +25,6 @@ export default defineConfig({
         }),
       ],
     }),
-    viteRenderCode(),
     viteMockServe({
       mockPath: './src/mock'
     })

--- a/site/vue3/vitePlugin/viteRenderCode.ts
+++ b/site/vue3/vitePlugin/viteRenderCode.ts
@@ -1,5 +1,16 @@
-import { PluginOption } from "vite";
-import { parse, compileTemplate } from "@vue/compiler-sfc";
+import type {Options, default as vuePlugin} from "@vitejs/plugin-vue";
+import {
+  compile,
+  parse,
+  RootNode,
+  TemplateChildNode,
+  ComponentNode,
+  DirectiveNode,
+  findProp,
+  createSimpleExpression,
+  NodeTypes,
+} from '@vue/compiler-dom'
+import { isStringLiteral, isArrayExpression, objectExpression, objectProperty, ObjectProperty, stringLiteral, arrayExpression} from '@babel/types'
 import { readFileSync } from "fs";
 
 const htmlEntities: { [key: string]: string } = {
@@ -20,58 +31,125 @@ const htmlEntities: { [key: string]: string } = {
 };
 
 const escapeHtml = (str: string) => {
-  return str?.replace(/[&<>'"`^~—•–?:$]/g, (tag) => htmlEntities[tag] || tag);
+  return str?.replace(/[&<>'"`^~—•–?:$]/g, (tag) => htmlEntities[tag] || tag) ?? '';
 };
 
-function viteRenderCode(): PluginOption {
-  let _originalConfig;
+const findAllCodeNode = (ast: RootNode) => {
+  const codeNodeList: ComponentNode[] = []
+  type Node = RootNode | TemplateChildNode
+  type Child<T> = T extends { children: Array<infer U> } ? U : never
+  let list: Array<Node | Child<Node>> = [ast]
+  while (list.length) {
+    const node = list.shift()
+    if (typeof node === 'object' && 'tag' in node &&  /^(CodeDemo|code-demo)$/.test(node.tag)) {
+      codeNodeList.push(node as ComponentNode)
+    }
+    if (typeof node === 'object' && 'children' in node && node.children.length) {
+      list = list.concat(...node.children)
+    }
+  }
+  return codeNodeList;
+}
+
+const getFileListValue = (node: ComponentNode) => {
+  const fileListProp = findProp(node, 'fileList', true) as DirectiveNode|undefined
+  const fileListAST = fileListProp?.exp?.ast ?? null
+  const fileListArrAST =
+  fileListAST && isArrayExpression(fileListAST) ? fileListAST : null
+  return fileListArrAST?.elements
+      ?.filter?.((item) => isStringLiteral(item))
+      ?.map?.((item) => item.value) ?? []
+}
+
+const createBindStrNode = (key: string, value: string): DirectiveNode => {
   return {
-    name: "vite-render-code",
-    enforce: "pre",
-    config(config) {
+    type: NodeTypes.DIRECTIVE,
+    name: 'bind',
+    exp: createSimpleExpression(JSON.stringify(value)),
+    arg: createSimpleExpression(key, true),
+    modifiers: [],
+    loc: {} as any
+  }
+}
+
+const createBindNode = (key: string, value: Record<string, string>[]): DirectiveNode => {
+  const arrNode = value.map(item => {
+    const properties: ObjectProperty[] = []
+    for (const key in item) {
+      properties.push(objectProperty(stringLiteral(key), stringLiteral(item[key])))
+    }
+    return objectExpression(properties)
+  })
+  return {
+    type: NodeTypes.DIRECTIVE,
+    name: 'bind',
+    exp: Object.assign(createSimpleExpression(JSON.stringify(value), false), {
+      ast: arrayExpression(arrNode),
+      // loc: null
+    }),
+    arg: createSimpleExpression(key, true),
+    modifiers: [],
+    loc: {} as any
+  }
+}
+const addBindProp = (comp: ComponentNode, key: string, bind: DirectiveNode) => {
+  const oldBind = findProp(comp, key, true) as DirectiveNode|undefined
+  if (oldBind) {
+    Object.assign(oldBind, bind)
+  } else {
+    comp.props.push(bind)
+  }
+}
+
+function viteRenderCode(vue: typeof vuePlugin, options: Options = {}) {
+  let _originalConfig;
+  const vueP = vue({
+    ...options,
+    template: {
+      compiler: {
+          compile(source, options) {
+            const currentPath = options.filename
+            if (typeof source !== 'string' || /\/node_modules\//.test(currentPath) || !/(CodeDemo|code-demo)/.test(source)) {
+              return compile(source, options)
+            }
+            const ast = parse(source, options)
+            const codeNodeList = findAllCodeNode(ast)
+            if (!codeNodeList.length) {
+              return compile(ast, options)
+            }
+            const fileCode = readFileSync(currentPath, "utf-8");
+            for (const item of codeNodeList) {
+              const fileListArrValue = getFileListValue(item)
+              const fileListCode = fileListArrValue.map(item => {
+                const curAlias = item.split("/")[0];
+                const filePath = item.replace(curAlias, _originalConfig.resolve.alias[curAlias]);
+                const fileCode = readFileSync(filePath, "utf-8");
+                return {
+                  fileCode: escapeHtml(fileCode),
+                  filePath: filePath,
+                };
+              })
+              const directiveNode = createBindNode('fileCode', fileListCode)
+              addBindProp(item, 'fileCode', directiveNode)
+
+              const codePathNode = createBindStrNode('codePath', currentPath)
+              addBindProp(item, 'codePath', codePathNode)
+
+              const codeDataNode = createBindStrNode('codeData', escapeHtml(fileCode))
+              addBindProp(item, 'codeData', codeDataNode)
+            }
+            return compile(ast, options)
+          },
+          parse,
+      },
+    }
+  })
+  const vuePConfig = vueP.config as Function
+  return Object.assign(vueP, {
+    config(config, ...args: unknown[]) {
       _originalConfig = config;
-    },
-    transform(code, id) {
-      if (!/\.(tsx?|jsx?|less|vue)$/.test(id) || id.includes("node_modules")) {
-        return null;
-      }
-      if (code.indexOf("<code-demo") !== -1) {
-        const { descriptor } = parse(code);
-        const oldCode = escapeHtml(JSON.parse(JSON.stringify(code)));
-        const template = compileTemplate({ source: descriptor.template.content, filename: id, id });
-
-        let fileListProp = [];
-        let fileListCode = [];
-        template.ast.children.map((node: any) => {
-          if (node?.tag === "code-demo") {
-            node.props.map((prop: any) => {
-              if (prop.rawName === ":fileList") {
-                fileListProp = prop.exp.ast.elements.map((element: any) => element.value);
-                for (let item of fileListProp) {
-                  const curAlias = item.split("/")[0];
-                  const filePath = item.replace(curAlias, _originalConfig.resolve.alias[curAlias]);
-                  const fileCode = readFileSync(filePath, "utf-8");
-                  fileListCode.push({
-                    fileCode: escapeHtml(fileCode),
-                    filePath: filePath,
-                  });
-                }
-              }
-            });
-            return node;
-          }
-        });
-        code = code.replace(
-          /<\/script>/,
-          `const codeData =\`${oldCode}\`; const codePath = \`${id}\`;` +
-            `\n const fileCode = ${JSON.stringify(fileListCode)};` +
-            "\n</script>",
-        );
-        code = code.replace("<code-demo", '<code-demo :codeData="codeData" :codePath="codePath" :fileCode="fileCode"');
-      }
-
-      return code;
-    },
-  };
+      return vuePConfig.call(vueP, config, ...args)
+    }
+  })
 }
 export default viteRenderCode;


### PR DESCRIPTION
通过配置vue单文件编译插件实现对模板的解析和覆盖，完成源代码输入。已自测行为与正则实现版本一致。